### PR TITLE
Use `basePath` for all established links

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -109,7 +109,7 @@ strong {
   font-weight:700;
   }
 
-/* Links */
+/* links */
 a,
 a code {
   color:#3887BE;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "budo": "^6.0.2",
     "envify": "^3.4.0",
     "eslint": "^1.7.2",
-    "eslint-plugin-react": "^3.6.3",
+    "eslint-plugin-react": "^3.10.0",
     "smokestack": "^3.4.1",
     "tap-status": "^1.0.1",
     "tape": "^4.2.2"

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -238,7 +238,7 @@ export function loadUser(u) {
   };
 }
 
-export function loadTeam(query) {
+export function loadTeam() {
   return (dispatch, getState) => {
     const { options } = getState().directory;
     const config = {};

--- a/src/components/filter.js
+++ b/src/components/filter.js
@@ -20,17 +20,17 @@ export default class Filter extends Component {
   }
 
   sort(e) {
-    const { sort, updatePath, query } = this.props;
+    const { directory, sort, updatePath, query } = this.props;
     const index = encodeURIComponent(e.target.id);
     const value = encodeURIComponent(e.target.value);
-    updatePath(query.filter ? `/?filter=${query.filter}&sort=${value}` : `/?sort=${value}`);
+    updatePath(query.filter ? `${directory.options.basePath}?filter=${query.filter}&sort=${value}` : `/?sort=${value}`);
     sort(index);
   }
 
   filter(e) {
-    const { filter, updatePath, query } = this.props;
+    const { directory, filter, updatePath, query } = this.props;
     const value = encodeURIComponent(e.target.value);
-    updatePath(query.sort ? `/?filter=${value}&sort=${query.sort}` : `/?filter=${value}`);
+    updatePath(query.sort ? `${directory.options.basePath}?filter=${value}&sort=${query.sort}` : `/?filter=${value}`);
     filter(value);
   }
 
@@ -64,6 +64,7 @@ Filter.propTypes = {
   sortKeys: PropTypes.array.isRequired,
   updatePath: PropTypes.func.isRequired,
   query: PropTypes.object.isRequired,
+  directory: PropTypes.object.isRequired,
   filter: PropTypes.func.isRequired,
   sort: PropTypes.func
 };

--- a/src/components/notfound.js
+++ b/src/components/notfound.js
@@ -1,16 +1,20 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { Link } from 'react-router';
+import * as actions from '../actions';
 import DocumentTitle from 'react-document-title';
 
-export default class Repo extends Component {
+export default class NotFound extends Component {
   render() {
+  var { directory } = this.props
     return (
       <DocumentTitle title='Not found | Us'>
       <div className='center'>
         <h2 className='block space-bottom2'>Page not found</h2>
         <Link
           className='button pad4x'
-          to='/'>
+          to={directory.options.basePath}>
           Back home?
         </Link>
       </div>
@@ -18,3 +22,17 @@ export default class Repo extends Component {
     );
   }
 }
+
+NotFound.PropTypes = {
+  directory: PropTypes.object.isRequired,
+}
+
+function mapStateToProps(state) {
+  return state;
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(Object.assign({}, actions), dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(NotFound);

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -29,13 +29,13 @@ class App extends Component {
               <IndexLink
                 className='strong animate pad2y pad0x'
                 activeClassName='active'
-                to='/'>
+                to={directory.options.basePath}>
                 Team listing
               </IndexLink>
               <Link
                 className='strong animate pad2y pad0x'
                 activeClassName='active'
-                to={'/new'}>
+                to={`${directory.options.basePath}new`}>
                 New member
               </Link>
             </nav>

--- a/src/containers/edit.js
+++ b/src/containers/edit.js
@@ -10,18 +10,18 @@ import Form from '../components/form';
 class EditUser extends Component {
   componentWillMount() {
     const { directory, loadUser, reRoute, routeParams } = this.props;
-    const { actor } = directory;
+    const { actor, options } = directory;
     const username = routeParams.user;
 
     if (!actor.admin) {
-      if (username.toLowerCase() !== actor.login.toLowerCase()) reRoute('/404');
+      if (username.toLowerCase() !== actor.login.toLowerCase()) reRoute(options.basePath + '404');
     }
 
     loadUser(username);
   }
 
   removeUser() {
-    const { removeUser, routeParams, setMessage, setError, reRoute } = this.props;
+    const { directory, removeUser, routeParams, setMessage, setError, reRoute } = this.props;
     const user = routeParams.user;
     const prompt = window.prompt('Are you sure? Enter their GitHub username to continue');
 
@@ -34,7 +34,7 @@ class EditUser extends Component {
           action: 'Okay',
           onClickHandler: () => {
             setMessage('');
-            reRoute('/');
+            reRoute(directory.options.basePath);
           }
         });
       });
@@ -44,7 +44,7 @@ class EditUser extends Component {
   }
 
   editUser(obj) {
-    const { updateUser, setMessage, setError, reRoute } = this.props;
+    const { directory, updateUser, setMessage, setError, reRoute } = this.props;
     updateUser(obj, (err) => {
       if (err) return setError(err);
       setMessage({
@@ -53,7 +53,7 @@ class EditUser extends Component {
         action: 'Okay',
         onClickHandler: () => {
           setMessage('');
-          reRoute('/');
+          reRoute(directory.options.basePath);
         }
       });
     });

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -114,6 +114,7 @@ class Index extends Component {
               </div>
             </div>
             <Filter
+              directory={directory}
               sortKeys={sortKeys}
               updatePath={reRoute}
               filter={teamFilter}
@@ -139,7 +140,7 @@ class Index extends Component {
         </div> : <div className='center'>
           <h2>No users.</h2>
           <div className='pad2y'>
-            <Link className='button pad4x' to={'/new'}>Create one?</Link>
+            <Link className='button pad4x' to={`${directory.options.basePath}new`}>Create one?</Link>
           </div>
         </div>}
       </DocumentTitle>

--- a/src/containers/new.js
+++ b/src/containers/new.js
@@ -8,7 +8,7 @@ import Form from '../components/form';
 
 class NewUser extends Component {
   addNewUser(obj) {
-    const { addUser, setMessage, setError, reRoute } = this.props;
+    const { directory, addUser, setMessage, setError, reRoute } = this.props;
     addUser(obj, (err) => {
       if (err) return setError(err);
       setMessage({
@@ -17,7 +17,7 @@ class NewUser extends Component {
         action: 'Okay',
         onClickHandler: () => {
           setMessage('');
-          reRoute('/');
+          reRoute(directory.options.basePath);
         }
       });
     });

--- a/src/containers/notfound.js
+++ b/src/containers/notfound.js
@@ -7,7 +7,7 @@ import DocumentTitle from 'react-document-title';
 
 export default class NotFound extends Component {
   render() {
-  var { directory } = this.props
+    var { directory } = this.props
     return (
       <DocumentTitle title='Not found | Us'>
       <div className='center'>
@@ -23,7 +23,7 @@ export default class NotFound extends Component {
   }
 }
 
-NotFound.PropTypes = {
+NotFound.propTypes = {
   directory: PropTypes.object.isRequired,
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ import App from './containers/app';
 import Index from './containers/index';
 import Edit from './containers/edit';
 import New from './containers/new';
-import NotFound from './components/notfound';
+import NotFound from './containers/notfound';
 import {
   setSorts,
   setOptions,


### PR DESCRIPTION
Pass basePath to links in the interface. basePath is registered as a prop and its a tradeoff for the simplicity of redux router to prefix it.
