### PR TITLE
Update vcf vCard module from 0.2.0 → 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
     "redux": "^3.0.2",
     "redux-simple-router": "0.0.10",
     "redux-thunk": "^1.0.0",
-    "vcf": "^0.2.0"
+    "vcf": "^1.1.2"
   }
 }

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -78,10 +78,10 @@ class Index extends Component {
     directory.team.forEach((d) => {
       const nameIsAscii = (d.lname + d.fname).match(/[^ -~]/) === null;
       card.push((new VCard())
-        .set('N', d.lname + ';' + d.fname, nameIsAscii ? {} : {charset: 'UTF-8'})
-        .set('EMAIL', d.email)
-        .set('ORG', directory.options.account)
-        .set('TEL', d.cell)
+        .set('n', d.lname + ';' + d.fname, nameIsAscii ? {} : {charset: 'UTF-8'})
+        .set('email', d.email)
+        .set('org', directory.options.account)
+        .set('tel', d.cell)
         .toString());
     });
     return 'data:text/vcard;charset=utf-8;base64,' + Base64.encode(card.join('\n'));

--- a/src/initial_state.js
+++ b/src/initial_state.js
@@ -32,9 +32,9 @@ const initialState = {
 function vCard(d) {
   const nameIsAscii = (d.lname + d.fname).match(/[^ -~]/) === null;
   const card = (new VCard())
-    .set('N', d.lname + ';' + d.fname, nameIsAscii ? {} : {charset: 'UTF-8'})
-    .set('EMAIL', d.email)
-    .set('TEL', d.cell)
+    .set('n', d.lname + ';' + d.fname, nameIsAscii ? {} : {charset: 'UTF-8'})
+    .set('email', d.email)
+    .set('tel', d.cell)
     .toString();
 
   return 'data:text/vcard;charset=utf-8;base64,' + Base64.encode(card);


### PR DESCRIPTION
Hello, hello

I noticed that the `vcf` module was a bit outdated, and took a quick stab at updating it.

The only things in need of change (as far as I can see) were the property names,
as they are now automatically dash-cased and should be written in camel-case.
### Module Changes

Other changes since `0.2.0`

**Fixes:**
- Fix trim empty lines in `.normalize()`
- Fix missing return in `.get()`
- Parse JSON in `.fromJSON()`, if necessary
- Fix trim empty lines in `.parse()`
- Fix regex pattern to not match values
- Fix parsing `BEGIN`/`END`
- Fix rendering empty properties with `undefined` as value

**API:**
- Add `.toJCard([version='4.0'])`
- Add `.setProperty()`
- Add test case for base64 encoded photos
- Add `vCard.parseMultiple()`
- Implement `vCard.format()`, `vCard#toString()`
- Implement `vCard.fromJSON()`, `Property.fromJSON()`
- Remove data-types, parameters, properties
- Remove cardinality guard
